### PR TITLE
Optimize Playwright installation for self-hosted runners

### DIFF
--- a/.github/actions/test/client/action.yml
+++ b/.github/actions/test/client/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Install Playwright Browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps chromium
+      run: npx playwright install chromium
       shell: bash
 
     # Test suite run --------------------------------

--- a/.github/actions/test/e2e/action.yml
+++ b/.github/actions/test/e2e/action.yml
@@ -81,7 +81,7 @@ runs:
 
     - name: Install Playwright Browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps chromium
+      run: npx playwright install chromium
       shell: bash
 
     # Docker node image ----------------------------


### PR DESCRIPTION
## Summary

This PR optimizes Playwright browser installation for self-hosted runners by removing the `--with-deps` flag from test actions.

## Changes

- **test/client/action.yml**: Changed from `npx playwright install --with-deps chromium` to `npx playwright install chromium`
- **test/e2e/action.yml**: Changed from `npx playwright install --with-deps chromium` to `npx playwright install chromium`

## Why?

Since the Wallet repository now uses `hello_arm` (self-hosted runner) for PR tests:

1. System dependencies installed by `--with-deps` persist on the runner between workflow runs
2. `cache.yml` already installs with `--with-deps` once, ensuring all system dependencies are present
3. Re-running `--with-deps` on every test run is redundant and adds ~10-30 seconds to setup time

## Benefits

- Faster test setup time (~10-30 seconds saved per test run)
- Reduced unnecessary apt-get operations
- Browser binaries are still properly restored from cache when available

## Related

This optimization was discovered while fixing cache misses in https://github.com/hellocoop/Wallet/actions/runs/20764267293/job/59626712679


🤖 Generated with [Claude Code](https://claude.com/claude-code)