### PR TITLE
Upload .well-known/ and mobile sub-paths in client deploy

### DIFF
--- a/.github/workflows/code-deploy-client.yml
+++ b/.github/workflows/code-deploy-client.yml
@@ -110,7 +110,21 @@ jobs:
           done
 
       - name: Copy S3 assets to S3 bucket with the AWS CLI
-        run: aws s3 cp --metadata version=${HELLO_VERSION} ${{inputs.BUILD_DIR}}/assets s3://${BUCKET_NAME}/assets --recursive 
+        run: aws s3 cp --metadata version=${HELLO_VERSION} ${{inputs.BUILD_DIR}}/assets s3://${BUCKET_NAME}/assets --recursive
+
+      - name: Upload .well-known directory if present
+        run: |
+          cd ${{inputs.BUILD_DIR}}
+          if [ -d ".well-known" ]; then
+            aws s3 cp --metadata version=${HELLO_VERSION} --content-type "application/json" --cache-control max-age=3600 .well-known/ s3://${BUCKET_NAME}/.well-known/ --recursive
+          fi
+
+      - name: Upload mobile fallback to sub-paths
+        run: |
+          cd ${{inputs.BUILD_DIR}}
+          if [ -f "mobile" ]; then
+            aws s3 cp --metadata version=${HELLO_VERSION} --content-type "text/html; charset=UTF-8" --cache-control max-age=0 mobile s3://${BUCKET_NAME}/mobile/callback
+          fi
 
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id ${DISTRIBUTION_ID} --paths "/*"


### PR DESCRIPTION
## Summary
- Upload `.well-known/` directory to S3 if present (the `for file in *` loop skips dotdirs)
- Upload `mobile` file as `mobile/callback` S3 key (fallback page for iOS ASWebAuthenticationSession)

## Context
The Wallet repo now has:
- `.well-known/apple-app-site-association` for iOS universal links and App Clips
- A `mobile` fallback page that needs to be served at both `/mobile` and `/mobile/callback`

The `.well-known/` file was never reaching S3 because shell `*` glob skips dotfiles/dotdirs. The `mobile/callback` key is needed because S3 serves by exact key name and there's no server-side redirect for sub-paths.

## Test plan
- [ ] Deploy Wallet to beta, verify `https://wallet.hello-beta.net/.well-known/apple-app-site-association` returns JSON
- [ ] Verify `https://wallet.hello-beta.net/mobile` returns HTML
- [ ] Verify `https://wallet.hello-beta.net/mobile/callback` returns HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)