### PR TITLE
Use HEAD for GIT_COMMIT label after checkout

### DIFF
--- a/.github/workflows/code-deploy-server.yml
+++ b/.github/workflows/code-deploy-server.yml
@@ -79,7 +79,11 @@ jobs:
       - name: Set HELLO_VERSION, GIT_COMMIT, IMAGE, ECR, and REPO_ARN
         run: |
           VERSION=$(jq -r '.version' package.json)
-          GIT_SHA_SHORT=$(git rev-parse --short ${{ github.sha }})
+          # Use HEAD of the just-checked-out TARGET_BRANCH rather than
+          # github.sha. For pull_request_target events, github.sha is the
+          # base branch's tip *at event time*, which lags the post-merge
+          # tip and yields a stale commit label on the deployed image.
+          GIT_SHA_SHORT=$(git rev-parse --short HEAD)
           ECR=${{ inputs.AWS_ACCOUNT }}.dkr.ecr.${AWS_REGION}.amazonaws.com
           REPO_ARN=${ECR}/${IMAGE}
           echo "HELLO_VERSION=${VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- For `pull_request_target` events, `github.sha` is the **tip of the base branch at event time**, which lags the post-merge tip and yields a stale commit label on the deployed image
- After checkout, `git rev-parse --short HEAD` reflects what was actually pulled (TARGET_BRANCH's current tip), so the label matches the image content

## Context
Discovered while deploying Wallet PR #3867 to beta — image content was current but `/api/health/deploy` reported an older commit SHA, making deploy verification confusing.

## Test plan
- [ ] Next deploy after merge: verify `/api/health/deploy` commit matches merged commit short SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)